### PR TITLE
improve: add redis dependency and remove suggested packages (moved to framework)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": ">=8.2",
         "friendsofhyperf/tinker": "~3.1.0",
-        "hypervel/framework": "^0.2"
+        "hypervel/framework": "^0.2",
+        "hypervel/redis": "^0.2"
     },
     "require-dev": {
         "fakerphp/faker": "^1.24.1",
@@ -46,27 +47,6 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "suggest": {
-        "ext-redis": "Required to use Redis-based drivers, such as cache, session, queue, etc.",
-        "ext-fileinfo": "Required to use the Filesystem class.",
-        "ext-ftp": "Required to use the Flysystem FTP driver.",
-        "ext-hash": "Required to use the Filesystem class.",
-        "ext-pcntl": "Required to use all features of the queue worker.",
-        "ext-posix": "Required to use all features of the queue worker.",
-        "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
-        "league/flysystem-path-prefixing": "Required to use the scoped driver (^3.3).",
-        "league/flysystem-read-only": "Required to use read-only disks (^3.3)",
-        "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.0).",
-        "flysystem-google-cloud-storage": "Required to use the Flysystem Google Cloud Storage driver (^3.0).",
-        "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.0).",
-        "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.0).",
-        "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
-        "symfony/http-client": "Required to use the Symfony API mail transports (^6.2).",
-        "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^6.2).",
-        "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^6.2).",
-        "pda/pheanstalk": "Required to use the Beanstalk queue driver (^5.0)."
-    },
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true


### PR DESCRIPTION
Because `hyperf/redis` requires `ext-redis`, we move `hyperf/redis` from framework to skeleton to make it optional for users.